### PR TITLE
fix AC_CHECK_SIZEOF doc

### DIFF
--- a/autoconf/checks.bzl
+++ b/autoconf/checks.bzl
@@ -911,7 +911,7 @@ def _ac_check_sizeof(
     # → Creates cache variable: "ac_cv_sizeof_int"
 
     # Cache variable + define (explicit name)
-    macros.AC_CHECK_SIZEOF("size_t", includes = ["stddef.h"], define = "SIZEOF_SIZE_T")
+    macros.AC_CHECK_SIZEOF("size_t", includes = ["#include <stddef.h>"], define = "SIZEOF_SIZE_T")
     # → Creates cache variable: "ac_cv_sizeof_size_t"
     # → Creates define: "SIZEOF_SIZE_T" in config.h
     ```


### PR DESCRIPTION
doc example show
```
macros.AC_CHECK_SIZEOF("size_t", includes = ["stddef.h"], define = "SIZEOF_SIZE_T")
```
but actually correct usage is 
```
macros.AC_CHECK_SIZEOF("size_t", includes = ["#include <stddef.h>"], define = "SIZEOF_SIZE_T")
```