### PR TITLE
split _autoconf_impl into small piece functions

### DIFF
--- a/autoconf/autoconf.bzl
+++ b/autoconf/autoconf.bzl
@@ -36,27 +36,7 @@ def _extract_define_name(expr):
 
     return required_define
 
-def _autoconf_impl(ctx):
-    """Implementation of the autoconf rule that only runs checks."""
-
-    # Get cc_toolchain info
-    toolchain_info = get_cc_toolchain_info(ctx)
-
-    # Get transitive dependencies to compute compile_defines paths
-    deps = collect_deps(ctx.attr.deps)
-    dep_infos = deps.to_list()
-    dep_results = collect_transitive_results(dep_infos)
-
-    cache_checks = {}
-    define_checks = {}
-    subst_checks = {}
-
-    cache_results = {}
-    define_results = {}
-    subst_results = {}
-
-    actions = {}
-
+def _add_all_checks(ctx, all_info):
     # Process all checks
     for check_json in ctx.attr.checks:
         check = json.decode(check_json)
@@ -80,48 +60,48 @@ def _autoconf_impl(ctx):
         if define:
             check["define"] = define_name
 
-            if define_name in define_results:
+            if define_name in all_info.define_results:
                 fail("Define variable `{}` is duplicated on `{}`\nLEFT:  {}\nRIGHT: {}".format(
                     define_name,
                     ctx.label,
-                    define_checks[define_name],
+                    all_info.define_checks[define_name],
                     check,
                 ))
 
-            define_checks[define_name] = check
+            all_info.define_checks[define_name] = check
 
             # Use cache file directly - no symlink needed
-            define_results[define_name] = output
+            all_info.define_results[define_name] = output
 
         # Check for truthy value
         if subst:
             check["subst"] = subst_name
 
-            if subst_name in subst_checks:
+            if subst_name in all_info.subst_checks:
                 fail("Subst variable `{}` is duplicated on `{}`\nLEFT:  {}\nRIGHT: {}".format(
                     subst_name,
                     ctx.label,
-                    subst_checks[subst_name],
+                    all_info.subst_checks[subst_name],
                     check,
                 ))
 
-            subst_checks[subst_name] = check
+            all_info.subst_checks[subst_name] = check
 
             # Use cache file directly - no symlink needed
-            subst_results[subst_name] = output
+            all_info.subst_results[subst_name] = output
 
         # Always add cache variable to cache_results, even if define/subst are set
         # This allows other checks to reference the cache variable in conditions
-        if name in cache_results:
+        if name in all_info.cache_results:
             fail("Cache variable `{}` is duplicated on `{}`\nLEFT:  {}\nRIGHT: {}".format(
                 name,
                 ctx.label,
-                cache_checks[name],
+                all_info.cache_checks[name],
                 check,
             ))
 
-        cache_checks[name] = check
-        cache_results[name] = output
+        all_info.cache_checks[name] = check
+        all_info.cache_results[name] = output
 
         check_json = ctx.actions.declare_file("{}/{}.check.json".format(ctx.label.name, name))
         ctx.actions.write(
@@ -129,14 +109,155 @@ def _autoconf_impl(ctx):
             content = json.encode_indent(check, indent = " " * 4) + "\n",
         )
 
-        if name in actions:
+        if name in all_info.actions:
             fail("Duplicate action identified `{}`. Please update `{}`".format(name, ctx.label))
 
-        actions[name] = struct(
+        all_info.actions[name] = struct(
             output = output,
             check = check,
             input = check_json,
         )
+
+def _check_duplicate(all_info, dep_results):
+    # Check for conflicts when merging local results with dependency results
+    # Same cache variable/define/subst from different sources should point to the same file
+    for cache_name, cache_file in dep_results["cache"].items():
+        if cache_name in all_info.cache_results:
+            existing_file = all_info.cache_results[cache_name]
+            if existing_file.path != cache_file.path:
+                fail("Cache variable '{}' is defined both locally and in dependencies with different result files:\n  Local:    {}\n  Dep:       {}\nThis indicates duplicate checks. Consider removing the local check or using a different cache variable name.".format(
+                    cache_name,
+                    existing_file.path,
+                    cache_file.path,
+                ))
+
+    for define_name, define_file in dep_results["define"].items():
+        if define_name in all_info.define_results:
+            existing_file = all_info.define_results[define_name]
+            if existing_file.path != define_file.path:
+                fail("Define '{}' is defined both locally and in dependencies with different result files:\n  Local:    {}\n  Dep:       {}\nThis indicates duplicate defines. Consider removing the local define or using a different name.".format(
+                    define_name,
+                    existing_file.path,
+                    define_file.path,
+                ))
+
+    for subst_name, subst_file in dep_results["subst"].items():
+        if subst_name in all_info.subst_results:
+            existing_file = all_info.subst_results[subst_name]
+            if existing_file.path != subst_file.path:
+                fail("Subst '{}' is defined both locally and in dependencies with different result files:\n  Local:    {}\n  Dep:       {}\nThis indicates duplicate subst. Consider removing the local subst or using a different name.".format(
+                    subst_name,
+                    existing_file.path,
+                    subst_file.path,
+                ))
+    pass
+
+def _unique_name_file_map(label, all_required_defines, all_results):
+    # Collect dependencies for all required defines
+    # Build a dictionary mapping lookup_name -> file_path
+    # This ensures strict deduplication before passing to C++
+    name_to_file = {}  # lookup_name -> file_path
+
+    for required_define in depset(all_required_defines).to_list():
+        dep_results_file = None
+        for group_name in ["cache", "define", "subst"]:
+            if required_define in getattr(all_results, group_name):
+                candidate_file = getattr(all_results, group_name)[required_define]
+                if dep_results_file:
+                    # Check if it's the same file (legitimate duplicate from AC_DEFINE with subst=True)
+                    if dep_results_file != candidate_file:
+                        # Check if this is a legitimate duplicate: same variable in both define and subst groups
+                        # When AC_DEFINE has subst=True and define_name == subst_name, both reference
+                        # the same cache file directly, so they're the same result
+                        is_legitimate_duplicate = (
+                            required_define in all_results.define and
+                            required_define in all_results.subst and
+                            group_name in ["define", "subst"]
+                        )
+                        if is_legitimate_duplicate:
+                            # Same variable in both define and subst - they reference the same cache file
+                            # Use the define file (arbitrary but consistent choice)
+                            if group_name == "subst":
+                                continue  # Skip subst, use define
+
+                            # If we already have define, skip this (shouldn't happen, but be safe)
+                            if dep_results_file == all_results.define[required_define]:
+                                continue
+
+                        # Different files - real conflict
+                        all_duplicates = {
+                            "cache": sorted([k for k in all_results.cache.keys() if k == required_define]),
+                            "define": sorted([k for k in all_results.define.keys() if k == required_define]),
+                            "subst": sorted([k for k in all_results.subst.keys() if k == required_define]),
+                        }
+                        fail("Duplicate results were found for check `{}`. Please update `{}`.\n Available options: {}".format(
+                            required_define,
+                            label,
+                            json.encode_indent(all_duplicates, indent = " " * 4) + "\n",
+                        ))
+
+                    # Same file - no conflict, continue (AC_DEFINE with subst=True case)
+                else:
+                    dep_results_file = candidate_file
+
+        if not dep_results_file:
+            all_available = {
+                "cache": sorted(all_results.cache.keys()),
+                "define": sorted(all_results.define.keys()),
+                "subst": sorted(all_results.subst.keys()),
+            }
+            fail("No results were found for check `{}`. Please update `{}`.\n Available options: {}".format(
+                required_define,
+                label,
+                json.encode_indent(all_available, indent = " " * 4) + "\n",
+            ))
+
+        # Deduplicate: check if this name is already mapped
+        if required_define in name_to_file:
+            if name_to_file[required_define] != dep_results_file:
+                fail("Duplicate lookup name '{}' maps to different files:\n  {} -> {}\n  {} -> {}\nThis indicates a bug in dependency resolution.".format(
+                    required_define,
+                    required_define,
+                    name_to_file[required_define],
+                    required_define,
+                    dep_results_file,
+                ))
+
+            # Same name, same file - idempotent, skip
+            continue
+
+        # Add mapping
+        name_to_file[required_define] = dep_results_file
+    return name_to_file
+
+def _collect_required_defines(check):
+    all_required_defines = []
+
+    for required in check.get("requires", []):
+        required_define = _extract_define_name(required)
+        all_required_defines.append(required_define)
+
+    condition = check.get("condition")
+    if condition:
+        required_define = _extract_define_name(condition)
+        all_required_defines.append(required_define)
+
+    for required in check.get("compile_defines", []):
+        required_define = _extract_define_name(required)
+        all_required_defines.append(required_define)
+
+    return all_required_defines
+
+def _checks_to_build_info(ctx):
+    """Implementation of the autoconf rule that only runs checks."""
+
+    # Get cc_toolchain info
+    toolchain_info = get_cc_toolchain_info(ctx)
+
+    # Get transitive dependencies to compute compile_defines paths
+    deps = collect_deps(ctx.attr.deps)
+    dep_infos = deps.to_list()
+    dep_results = collect_transitive_results(dep_infos)
 
     # Write config to JSON
     config_json = write_config_json(ctx, create_config_dict(
@@ -149,151 +270,52 @@ def _autoconf_impl(ctx):
     # variable from the compile action is crucial for finding standard headers like stdint.h
     env = get_environment_variables(ctx, toolchain_info)
 
-    inputs = [config_json]
+    all_info = struct(
+        env = env,
+        config_json = config_json,
+        toolchain_info = toolchain_info,
+        deps = deps,
+        cache_checks = {},
+        define_checks = {},
+        subst_checks = {},
+        cache_results = {},
+        define_results = {},
+        subst_results = {},
+        actions = {},
+        cache = {},
+        define = {},
+        subst = {},
+    )
 
-    # Check for conflicts when merging local results with dependency results
-    # Same cache variable/define/subst from different sources should point to the same file
-    for cache_name, cache_file in dep_results["cache"].items():
-        if cache_name in cache_results:
-            existing_file = cache_results[cache_name]
-            if existing_file.path != cache_file.path:
-                fail("Cache variable '{}' is defined both locally and in dependencies with different result files:\n  Local:    {}\n  Dep:       {}\nThis indicates duplicate checks. Consider removing the local check or using a different cache variable name.".format(
-                    cache_name,
-                    existing_file.path,
-                    cache_file.path,
-                ))
+    _add_all_checks(ctx, all_info)
+    _check_duplicate(all_info, dep_results)
 
-    for define_name, define_file in dep_results["define"].items():
-        if define_name in define_results:
-            existing_file = define_results[define_name]
-            if existing_file.path != define_file.path:
-                fail("Define '{}' is defined both locally and in dependencies with different result files:\n  Local:    {}\n  Dep:       {}\nThis indicates duplicate defines. Consider removing the local define or using a different name.".format(
-                    define_name,
-                    existing_file.path,
-                    define_file.path,
-                ))
+    all_info.cache.update(all_info.cache_results | dep_results["cache"])
+    all_info.define.update(all_info.define_results | dep_results["define"])
+    all_info.subst.update(all_info.subst_results | dep_results["subst"])
 
-    for subst_name, subst_file in dep_results["subst"].items():
-        if subst_name in subst_results:
-            existing_file = subst_results[subst_name]
-            if existing_file.path != subst_file.path:
-                fail("Subst '{}' is defined both locally and in dependencies with different result files:\n  Local:    {}\n  Dep:       {}\nThis indicates duplicate subst. Consider removing the local subst or using a different name.".format(
-                    subst_name,
-                    existing_file.path,
-                    subst_file.path,
-                ))
+    return all_info
 
-    all_results = {
-        "cache": cache_results | dep_results["cache"],
-        "define": define_results | dep_results["define"],
-        "subst": subst_results | dep_results["subst"],
-    }
+def _autoconf_impl(ctx):
+    all_info = _checks_to_build_info(ctx)
 
     # Create individual CcAutoconfCheck actions for each cache variable
     # All checks sharing the same cache variable are processed together
     # (checks is already grouped by cache_name from _flatten_checks)
-    for check_name, action in actions.items():
+    for check_name, action in all_info.actions.items():
         check_result_file = action.output
         check = action.check
         check_json = action.input
 
-        all_required_defines = []
-
-        for required in check.get("requires", []):
-            required_define = _extract_define_name(required)
-            all_required_defines.append(required_define)
-
-        condition = check.get("condition")
-        if condition:
-            required_define = _extract_define_name(condition)
-            all_required_defines.append(required_define)
-
-        for required in check.get("compile_defines", []):
-            required_define = _extract_define_name(required)
-            all_required_defines.append(required_define)
-
         args = ctx.actions.args()
         args.use_param_file("@%s", use_always = True)
         args.set_param_file_format("multiline")
-        args.add("--config", config_json)
+        args.add("--config", all_info.config_json)
         args.add("--check", check_json)
         args.add("--results", check_result_file)
 
-        # Collect dependencies for all required defines
-        # Build a dictionary mapping lookup_name -> file_path
-        # This ensures strict deduplication before passing to C++
-        name_to_file = {}  # lookup_name -> file_path
-
-        for required_define in depset(all_required_defines).to_list():
-            dep_results_file = None
-            for group_name in ["cache", "define", "subst"]:
-                if required_define in all_results[group_name]:
-                    candidate_file = all_results[group_name][required_define]
-                    if dep_results_file:
-                        # Check if it's the same file (legitimate duplicate from AC_DEFINE with subst=True)
-                        if dep_results_file != candidate_file:
-                            # Check if this is a legitimate duplicate: same variable in both define and subst groups
-                            # When AC_DEFINE has subst=True and define_name == subst_name, both reference
-                            # the same cache file directly, so they're the same result
-                            is_legitimate_duplicate = (
-                                required_define in all_results["define"] and
-                                required_define in all_results["subst"] and
-                                group_name in ["define", "subst"]
-                            )
-                            if is_legitimate_duplicate:
-                                # Same variable in both define and subst - they reference the same cache file
-                                # Use the define file (arbitrary but consistent choice)
-                                if group_name == "subst":
-                                    continue  # Skip subst, use define
-
-                                # If we already have define, skip this (shouldn't happen, but be safe)
-                                if dep_results_file == all_results["define"][required_define]:
-                                    continue
-
-                            # Different files - real conflict
-                            all_duplicates = {
-                                "cache": sorted([k for k in all_results["cache"].keys() if k == required_define]),
-                                "define": sorted([k for k in all_results["define"].keys() if k == required_define]),
-                                "subst": sorted([k for k in all_results["subst"].keys() if k == required_define]),
-                            }
-                            fail("Duplicate results were found for check `{}`. Please update `{}`.\n Available options: {}".format(
-                                required_define,
-                                ctx.label,
-                                json.encode_indent(all_duplicates, indent = " " * 4) + "\n",
-                            ))
-
-                        # Same file - no conflict, continue (AC_DEFINE with subst=True case)
-                    else:
-                        dep_results_file = candidate_file
-
-            if not dep_results_file:
-                all_available = {
-                    "cache": sorted(all_results["cache"].keys()),
-                    "define": sorted(all_results["define"].keys()),
-                    "subst": sorted(all_results["subst"].keys()),
-                }
-                fail("No results were found for check `{}`. Please update `{}`.\n Available options: {}".format(
-                    required_define,
-                    ctx.label,
-                    json.encode_indent(all_available, indent = " " * 4) + "\n",
-                ))
-
-            # Deduplicate: check if this name is already mapped
-            if required_define in name_to_file:
-                if name_to_file[required_define] != dep_results_file:
-                    fail("Duplicate lookup name '{}' maps to different files:\n  {} -> {}\n  {} -> {}\nThis indicates a bug in dependency resolution.".format(
-                        required_define,
-                        required_define,
-                        name_to_file[required_define],
-                        required_define,
-                        dep_results_file,
-                    ))
-
-                # Same name, same file - idempotent, skip
-                continue
-
-            # Add mapping
-            name_to_file[required_define] = dep_results_file
+        all_required_defines = _collect_required_defines(check)
+        name_to_file = _unique_name_file_map(ctx.label, all_required_defines, all_info)
 
         # Add --dep arguments with explicit name=file format
         check_deps = []
@@ -304,26 +326,26 @@ def _autoconf_impl(ctx):
         ctx.actions.run(
             executable = ctx.executable._checker,
             arguments = [args],
-            inputs = depset(inputs + [check_json] + check_deps),
+            inputs = depset([all_info.config_json] + [check_json] + check_deps),
             outputs = [check_result_file],
             mnemonic = "CcAutoconfCheck",
             progress_message = "CcAutoconfCheck %{label} - " + check_name,
-            env = env | ctx.configuration.default_shell_env,
-            tools = toolchain_info.cc_toolchain.all_files,
+            env = all_info.env | ctx.configuration.default_shell_env,
+            tools = all_info.toolchain_info.cc_toolchain.all_files,
         )
 
     # Return provider with three separate buckets
     return [
         CcAutoconfInfo(
             owner = ctx.label,
-            deps = deps,
-            cache_results = cache_results,
-            define_results = define_results,
-            subst_results = subst_results,
+            deps = all_info.deps,
+            cache_results = all_info.cache_results,
+            define_results = all_info.define_results,
+            subst_results = all_info.subst_results,
         ),
         OutputGroupInfo(
-            autoconf_checks = depset([action.input for action in actions.values()]),
-            autoconf_results = depset(cache_results.values() + define_results.values() + subst_results.values()),
+            autoconf_checks = depset([action.input for action in all_info.actions.values()]),
+            autoconf_results = depset(all_info.cache_results.values() + all_info.define_results.values() + all_info.subst_results.values()),
         ),
     ]
 

--- a/autoconf/autoconf.bzl
+++ b/autoconf/autoconf.bzl
@@ -152,7 +152,22 @@ def _check_duplicate(all_info, dep_results):
                 ))
     pass
 
-def _unique_name_file_map(label, all_required_defines, all_results):
+def _unique_name_file_map(label, check, all_results):
+    all_required_defines = []
+
+    for required in check.get("requires", []):
+        required_define = _extract_define_name(required)
+        all_required_defines.append(required_define)
+
+    condition = check.get("condition")
+    if condition:
+        required_define = _extract_define_name(condition)
+        all_required_defines.append(required_define)
+
+    for required in check.get("compile_defines", []):
+        required_define = _extract_define_name(required)
+        all_required_defines.append(required_define)
+
     # Collect dependencies for all required defines
     # Build a dictionary mapping lookup_name -> file_path
     # This ensures strict deduplication before passing to C++
@@ -230,24 +245,6 @@ def _unique_name_file_map(label, all_required_defines, all_results):
         name_to_file[required_define] = dep_results_file
     return name_to_file
 
-def _collect_required_defines(check):
-    all_required_defines = []
-
-    for required in check.get("requires", []):
-        required_define = _extract_define_name(required)
-        all_required_defines.append(required_define)
-
-    condition = check.get("condition")
-    if condition:
-        required_define = _extract_define_name(condition)
-        all_required_defines.append(required_define)
-
-    for required in check.get("compile_defines", []):
-        required_define = _extract_define_name(required)
-        all_required_defines.append(required_define)
-
-    return all_required_defines
-
 def _checks_to_build_info(ctx):
     """Implementation of the autoconf rule that only runs checks."""
 
@@ -296,6 +293,28 @@ def _checks_to_build_info(ctx):
 
     return all_info
 
+def _action_arg_dep(ctx, action, all_info):
+    check = action.check
+    check_json = action.input
+    check_result_file = action.output
+
+    args = ctx.actions.args()
+    args.use_param_file("@%s", use_always = True)
+    args.set_param_file_format("multiline")
+    args.add("--config", all_info.config_json)
+    args.add("--check", check_json)
+    args.add("--results", check_result_file)
+
+    name_to_file = _unique_name_file_map(ctx.label, check, all_info)
+
+    # Add --dep arguments with explicit name=file format
+    check_deps = []
+    for lookup_name, file_path in name_to_file.items():
+        check_deps.append(file_path)
+        args.add("--dep", "{}={}".format(lookup_name, file_path.path))
+
+    return (args, depset([all_info.config_json] + [check_json] + check_deps))
+
 def _autoconf_impl(ctx):
     all_info = _checks_to_build_info(ctx)
 
@@ -304,29 +323,12 @@ def _autoconf_impl(ctx):
     # (checks is already grouped by cache_name from _flatten_checks)
     for check_name, action in all_info.actions.items():
         check_result_file = action.output
-        check = action.check
-        check_json = action.input
-
-        args = ctx.actions.args()
-        args.use_param_file("@%s", use_always = True)
-        args.set_param_file_format("multiline")
-        args.add("--config", all_info.config_json)
-        args.add("--check", check_json)
-        args.add("--results", check_result_file)
-
-        all_required_defines = _collect_required_defines(check)
-        name_to_file = _unique_name_file_map(ctx.label, all_required_defines, all_info)
-
-        # Add --dep arguments with explicit name=file format
-        check_deps = []
-        for lookup_name, file_path in name_to_file.items():
-            check_deps.append(file_path)
-            args.add("--dep", "{}={}".format(lookup_name, file_path.path))
+        args, deps = _action_arg_dep(ctx, action, all_info)
 
         ctx.actions.run(
             executable = ctx.executable._checker,
             arguments = [args],
-            inputs = depset([all_info.config_json] + [check_json] + check_deps),
+            inputs = deps,
             outputs = [check_result_file],
             mnemonic = "CcAutoconfCheck",
             progress_message = "CcAutoconfCheck %{label} - " + check_name,


### PR DESCRIPTION
This attempts to refactor _autoconf_impl to improve reusability for similar functionality (e.g., future Meson integration).

Currently, _autoconf_impl:

* Parses checks JSON into structured data and collects check/define info
* Handles duplicate/conflict detection
* Prepares args/input/output for checker_bin

Changes in this PR:

* Extract the main loop into a helper function
* Consolidate preparation results into a single reusable structure

This allows the preparation step to be reused, e.g., as a basis for eval_expr.