### PR TITLE
Fix errors from specific rules_cc features

### DIFF
--- a/autoconf/private/autoconf_config.bzl
+++ b/autoconf/private/autoconf_config.bzl
@@ -285,6 +285,23 @@ def collect_deps(deps):
 
     return depset(direct, transitive = transitive)
 
+# Some features are incompatible with the probing and result in errors
+# across various toolchain implementations and rules_cc versions.
+_UNSUPPORTED_RULES_CC_FEATURES = [
+    # Enforces declared-only header use; needs `%{module_name}` + cc_library module map.
+    "layering_check",
+    # Adds `-fmodule-map-file` / `-fmodule-name` to compiles; needs module map variables.
+    "use_module_maps",
+    # Toolchain capability to emit `.cppmap` files for cc_library hdrs; no hdrs here.
+    "module_maps",
+    # Synthesizes per-header `-fsyntax-only` actions for cc_library hdrs; nothing to parse.
+    "parse_headers",
+    # Compiles cc_library hdrs into clang PCMs; needs `%{module_name}` + `.pcm` graph.
+    "header_modules",
+    # C++20 named modules orchestration; needs module interface unit context.
+    "cpp_modules",
+]
+
 def get_cc_toolchain_info(ctx):
     """Get cc_toolchain information for autoconf configuration.
 
@@ -309,7 +326,7 @@ def get_cc_toolchain_info(ctx):
         ctx = ctx,
         cc_toolchain = cc_toolchain,
         requested_features = ctx.features,
-        unsupported_features = ctx.disabled_features,
+        unsupported_features = ctx.disabled_features + _UNSUPPORTED_RULES_CC_FEATURES,
     )
 
     c_compiler_path = cc_common.get_tool_for_action(


### PR DESCRIPTION
This should fix errors like the following
```
ERROR: /home/gha/.cache/bazel/_bazel_gha/7e8ec8c8c4975cf00cc8d263f2c10e24/external/rules_cc_autoconf+/gnulib/m4/math_h/BUILD.bazel:90:9: in autoconf_cache rule @@rules_cc_autoconf+//gnulib/m4/math_h:gl_MATH_H_DEFAULTS: 
Traceback (most recent call last):
	File "/home/gha/.cache/bazel/_bazel_gha/7e8ec8c8c4975cf00cc8d263f2c10e24/external/rules_cc_autoconf+/autoconf/autoconf_toolchain.bzl", line 160, column 32, in _autoconf_cache_impl
		return autoconf_impl_common(ctx, resolve_toolchain = False)
	File "/home/gha/.cache/bazel/_bazel_gha/7e8ec8c8c4975cf00cc8d263f2c10e24/external/rules_cc_autoconf+/autoconf/private/autoconf_library.bzl", line 79, column 43, in autoconf_impl_common
		toolchain_info = get_cc_toolchain_info(ctx)
	File "/home/gha/.cache/bazel/_bazel_gha/7e8ec8c8c4975cf00cc8d263f2c10e24/external/rules_cc_autoconf+/autoconf/private/autoconf_config.bzl", line 336, column 60, in get_cc_toolchain_info
		c_flags = cc_common.get_memory_inefficient_command_line(
	File "/virtual_builtins_bzl/common/cc/cc_common.bzl", line 205, column 66, in _get_memory_inefficient_command_line
Error in get_memory_inefficient_command_line: Invalid toolchain configuration: Cannot find variable named 'module_name'.
```