### PR TITLE
Added support for build setting checks

### DIFF
--- a/autoconf/autoconf.bzl
+++ b/autoconf/autoconf.bzl
@@ -2,7 +2,69 @@
 
 load(
     "//autoconf/private:autoconf_library.bzl",
-    _autoconf = "autoconf",
+    "to_build_settings_dict",
+    _autoconf_rule = "autoconf",
 )
 
-autoconf = _autoconf
+def autoconf(
+        *,
+        name,
+        build_settings = None,
+        checks = None,
+        deps = None,
+        **kwargs):
+    """Run autoconf-like checks and produce results.
+
+    This rule resolves the `autoconf_toolchain` (when registered) to skip redundant
+    checker actions. If a check's cache variable name already has a result in the
+    toolchain or in transitive `deps`, the existing result file is reused.
+
+    Use `autoconf_cache` instead for targets that feed into `autoconf_toolchain`
+    to avoid a dependency cycle.
+
+    Example:
+
+    ```python
+    load("@rules_cc_autoconf//autoconf:autoconf.bzl", "autoconf")
+    load("@rules_cc_autoconf//autoconf:checks.bzl", "checks")
+
+    autoconf(
+        name = "config",
+        checks = [
+            checks.AC_CHECK_HEADER("stdio.h"),
+            checks.AC_CHECK_HEADER("stdlib.h"),
+            checks.AC_CHECK_FUNC("printf"),
+        ],
+    )
+    ```
+
+    The results can then be used by `autoconf_hdr` or `autoconf_srcs` to generate
+    headers or wrapped source files.
+
+    Args:
+        name: A unique name for this target.
+        build_settings: List of `checks.AC_BUILD_SETTING(...)` entries
+            associating Bazel build setting targets (any rule providing
+            `BuildSettingInfo`) with autoconf-style defines and substitutions.
+        checks: List of JSON-encoded checks from `checks`
+            (e.g., `checks.AC_CHECK_HEADER('stdio.h')`).
+        deps: Additional `autoconf`, `autoconf_cache`, or `package_info`
+            dependencies.
+        **kwargs: Standard Bazel attributes (e.g. `visibility`, `tags`).
+    """
+
+    # This is a macro rather than a direct rule re-export because the
+    # underlying `build_settings` attribute has to be a
+    # `label_keyed_string_dict` -- the only pre-Bazel-9 attr type that
+    # carries (Label, str) pairs natively. Once Bazel 9 is the minimum
+    # supported version, switch the rule attribute to
+    # `string_keyed_label_dict`, have `AC_BUILD_SETTING` return a one-key
+    # dict, and delete this macro -- the rule can then be re-exported
+    # directly.
+    _autoconf_rule(
+        name = name,
+        build_settings = to_build_settings_dict(build_settings),
+        checks = checks or [],
+        deps = deps or [],
+        **kwargs
+    )

--- a/autoconf/autoconf_toolchain.bzl
+++ b/autoconf/autoconf_toolchain.bzl
@@ -3,9 +3,8 @@
 Provides default autoconf checks that can be overridden by targets.
 """
 
-load("@rules_cc//cc:find_cc_toolchain.bzl", "use_cc_toolchain")
 load("//autoconf/private:autoconf_config.bzl", "collect_deps", "collect_transitive_results")
-load("//autoconf/private:autoconf_library.bzl", "COMMON_ATTRS", "autoconf_impl_common")
+load("//autoconf/private:autoconf_library.bzl", "to_build_settings_dict", _autoconf_cache_rule = "autoconf_cache")
 load("//autoconf/private:providers.bzl", "CcAutoconfInfo")
 
 def _autoconf_toolchain_impl(ctx):
@@ -156,24 +155,48 @@ dependencies with different result files"*:
     },
 )
 
-def _autoconf_cache_impl(ctx):
-    return autoconf_impl_common(ctx, resolve_toolchain = False)
+def autoconf_cache(
+        *,
+        name,
+        build_settings = None,
+        checks = None,
+        deps = None,
+        **kwargs):
+    """Run autoconf-like checks without resolving the autoconf toolchain.
 
-autoconf_cache = rule(
-    implementation = _autoconf_cache_impl,
-    doc = """\
-Run autoconf-like checks without resolving the autoconf toolchain.
+    Identical to `autoconf` except that it does **not** resolve the
+    `autoconf_toolchain`. Use this rule for targets that are listed as
+    `cache_deps` or `defaults` of an `autoconf_toolchain` -- using the
+    regular `autoconf` rule in that position would create a dependency cycle.
 
-Identical to ``autoconf`` except that it does **not** resolve the
-``autoconf_toolchain``.  Use this rule for targets that are listed as
-``cache_deps`` or ``defaults`` of an ``autoconf_toolchain`` -- using the
-regular ``autoconf`` rule in that position would create a dependency cycle.
+    Dep-level caching still applies: if a check's cache variable name already
+    has a result in transitive `deps`, the action is skipped.
 
-Dep-level caching still applies: if a check's cache variable name already
-has a result in transitive ``deps``, the action is skipped.
-""",
-    attrs = COMMON_ATTRS,
-    fragments = ["cpp"],
-    toolchains = use_cc_toolchain(),
-    provides = [CcAutoconfInfo],
-)
+    Args:
+        name: A unique name for this target.
+        build_settings: List of `checks.AC_BUILD_SETTING(...)` entries
+            associating Bazel build setting targets (any rule providing
+            `BuildSettingInfo`) with autoconf-style defines and substitutions.
+        checks: List of JSON-encoded checks from `checks`
+            (e.g., `checks.AC_CHECK_HEADER('stdio.h')`).
+        deps: Additional `autoconf`, `autoconf_cache`, or `package_info`
+            dependencies.
+        **kwargs: Standard Bazel attributes (e.g. `visibility`, `tags`).
+    """
+
+    # This is a macro rather than a direct rule re-export because the
+    # underlying `build_settings` attribute has to be a
+    # `label_keyed_string_dict` -- the only pre-Bazel-9 attr type that
+    # carries (Label, str) pairs natively. Once Bazel 9 is the minimum
+    # supported version, switch the rule attribute to
+    # `string_keyed_label_dict`, have `AC_BUILD_SETTING` return a one-key
+    # dict, and delete this macro -- the rule can then be re-exported
+    # directly. See `//autoconf:autoconf.bzl` for the matching transition
+    # on the `autoconf` rule.
+    _autoconf_cache_rule(
+        name = name,
+        build_settings = to_build_settings_dict(build_settings),
+        checks = checks or [],
+        deps = deps or [],
+        **kwargs
+    )

--- a/autoconf/checks.bzl
+++ b/autoconf/checks.bzl
@@ -2603,6 +2603,75 @@ def _ac_check_members(
 
     return checks
 
+def _ac_build_setting(
+        *,
+        target,
+        name,
+        define = None,
+        subst = None,
+        unquote = False):
+    """Associate a Bazel build setting target with an autoconf define/subst.
+
+    Reads the value of `target` (any rule providing `BuildSettingInfo`) at
+    analysis time and renders it as a pre-computed check result -- the same
+    shape `AC_DEFINE` / `AC_SUBST` produce -- so it flows through
+    `autoconf_hdr` / `autoconf_srcs` like any other check. No compilation is
+    performed.
+
+    The returned value is consumed by the `autoconf` (and `autoconf_cache`)
+    macro's `build_settings` parameter, which collects a list of these and
+    forwards them to the underlying rule.
+
+    Example:
+    ```python
+    load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+    load("@rules_cc_autoconf//autoconf:autoconf.bzl", "autoconf")
+    load("@rules_cc_autoconf//autoconf:checks.bzl", "checks")
+
+    string_flag(name = "package_name", build_setting_default = "myproj")
+
+    autoconf(
+        name = "config",
+        build_settings = [
+            checks.AC_BUILD_SETTING(
+                target = ":package_name",
+                name = "ac_cv_package_name",
+                define = "PACKAGE_NAME",
+                subst = True,
+            ),
+        ],
+    )
+    ```
+
+    Args:
+        target: Label of a target providing `BuildSettingInfo` (e.g. a
+            `string_flag`, `bool_flag`, or `int_flag`).
+        name: Cache variable name (e.g. `"ac_cv_package_name"`).
+        define: Define name to set in the generated header, or `True` to
+            reuse `name`. At least one of `define` or `subst` is required.
+        subst: Substitution variable name for `@VAR@` replacement, or `True`
+            to reuse `define`/`name`. At least one of `define` or `subst`
+            is required.
+        unquote: If True, emit the define with AC_DEFINE_UNQUOTED-style
+            (trailing space) instead of `/**/`.
+
+    Returns:
+        A struct consumed by the `autoconf` / `autoconf_cache` macro's
+        `build_settings` parameter.
+    """
+    if not define and not subst:
+        fail("AC_BUILD_SETTING for `{}` must set at least one of `define` or `subst`.".format(target))
+
+    return struct(
+        target = target,
+        metadata = json.encode({
+            "define": define,
+            "name": name,
+            "subst": subst,
+            "unquote": unquote,
+        }),
+    )
+
 def _ac_lang_program(prologue, body):
     """Build program code from prologue and main body (AC_LANG_PROGRAM).
 
@@ -2649,6 +2718,7 @@ def _ac_lang_program(prologue, body):
     return _AC_LANG_PROGRAM_TEMPLATE.format(prologue_str, body_str)
 
 checks = struct(
+    AC_BUILD_SETTING = _ac_build_setting,
     AC_C_RESTRICT = _ac_c_restrict,
     AC_CHECK_ALIGNOF = _ac_check_alignof,
     AC_CHECK_C_COMPILER_FLAG = _ac_check_c_compiler_flag,

--- a/autoconf/private/BUILD.bazel
+++ b/autoconf/private/BUILD.bazel
@@ -13,6 +13,7 @@ bzl_library(
     deps = [
         "@bazel_features//:features",
         "@bazel_skylib//lib:paths",
+        "@bazel_skylib//rules:common_settings",
         "@rules_cc//cc:action_names_bzl",
         "@rules_cc//cc:find_cc_toolchain_bzl",
         "@rules_cc//cc/common",

--- a/autoconf/private/autoconf_library.bzl
+++ b/autoconf/private/autoconf_library.bzl
@@ -1,12 +1,14 @@
 """autoconf implementation"""
 
 load("@bazel_features//:features.bzl", "bazel_features")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "use_cc_toolchain")
 load(
     "//autoconf/private:autoconf_config.bzl",
     "collect_deps",
     "collect_transitive_results",
     "create_config_dict",
+    "encode_result",
     "get_autoconf_toolchain_cache",
     "get_cc_toolchain_info",
     "get_environment_variables",
@@ -67,6 +69,100 @@ def _coerce_name(name, value):
         return value
 
     return name
+
+def _assert_no_duplicate(kind, name, registry, ctx, new_source):
+    """Fail when `name` is already registered for `kind` (Define or Subst).
+
+    Shared by the JSON-check loop and the build-settings loop so both produce
+    the same error shape on a duplicate symbol within a single target.
+    """
+    if name in registry:
+        fail("{} variable `{}` is duplicated on `{}`\nLEFT:  {}\nRIGHT: {}".format(
+            kind,
+            name,
+            ctx.label,
+            registry[name],
+            new_source,
+        ))
+
+def _process_build_settings(
+        ctx,
+        cache_results,
+        define_results,
+        subst_results,
+        content_cache,
+        unquoted_defines,
+        cache_checks,
+        define_checks,
+        subst_checks,
+        available_content_cache):
+    """Render each `build_settings` entry as a pre-computed check result.
+
+    For each (target, metadata_json) pair, read the BuildSettingInfo value,
+    write a result file containing ``encode_result(value)``, and register it
+    in the same cache/define/subst/content_cache dicts the JSON-check loop
+    populates. Content-key dedup applies the same way: two targets that
+    reference the same flag with the same resolved value share one file.
+    """
+    for target, metadata_json in ctx.attr.build_settings.items():
+        metadata = json.decode(metadata_json)
+        name = metadata.get("name")
+        if not name:
+            fail("Build setting entry for `{}` on `{}` is missing 'name'.".format(
+                target.label,
+                ctx.label,
+            ))
+        define = metadata.get("define")
+        subst = metadata.get("subst")
+        unquote = metadata.get("unquote", False)
+
+        define_name = _coerce_name(name, define)
+        subst_name = _coerce_name(name, _coerce_name(define_name, subst))
+
+        value = target[BuildSettingInfo].value
+        content_key = json.encode([
+            "build_setting",
+            str(target.label),
+            value,
+        ])
+
+        if content_key in content_cache and name in cache_results:
+            continue
+
+        if content_key in available_content_cache:
+            output = available_content_cache[content_key]
+        elif content_key in content_cache:
+            output = content_cache[content_key]
+        else:
+            output = ctx.actions.declare_file("{}/{}.result.cache.json".format(ctx.label.name, name))
+            write(
+                actions = ctx.actions,
+                output = output,
+                content = encode_result(value),
+            )
+
+        source_desc = {
+            "build_setting": str(target.label),
+            "define": define,
+            "name": name,
+            "subst": subst,
+        }
+
+        if define:
+            _assert_no_duplicate("Define", define_name, define_checks, ctx, source_desc)
+            define_checks[define_name] = source_desc
+            define_results[define_name] = output
+            if unquote:
+                unquoted_defines.append(define_name)
+
+        if subst:
+            _assert_no_duplicate("Subst", subst_name, subst_checks, ctx, source_desc)
+            subst_checks[subst_name] = source_desc
+            subst_results[subst_name] = output
+
+        cache_checks[name] = source_desc
+        cache_results[name] = output
+        content_cache[content_key] = output
 
 def autoconf_impl_common(ctx, resolve_toolchain):
     """Shared implementation for autoconf and autoconf_library rules.
@@ -154,15 +250,7 @@ def autoconf_impl_common(ctx, resolve_toolchain):
         # Define/subst conflict detection: different cache variable claiming same symbol = error
         if define:
             check["define"] = define_name
-
-            if define_name in define_results:
-                fail("Define variable `{}` is duplicated on `{}`\nLEFT:  {}\nRIGHT: {}".format(
-                    define_name,
-                    ctx.label,
-                    define_checks[define_name],
-                    check,
-                ))
-
+            _assert_no_duplicate("Define", define_name, define_checks, ctx, check)
             define_checks[define_name] = check
             define_results[define_name] = output
 
@@ -171,21 +259,26 @@ def autoconf_impl_common(ctx, resolve_toolchain):
 
         if subst:
             check["subst"] = subst_name
-
-            if subst_name in subst_checks:
-                fail("Subst variable `{}` is duplicated on `{}`\nLEFT:  {}\nRIGHT: {}".format(
-                    subst_name,
-                    ctx.label,
-                    subst_checks[subst_name],
-                    check,
-                ))
-
+            _assert_no_duplicate("Subst", subst_name, subst_checks, ctx, check)
             subst_checks[subst_name] = check
             subst_results[subst_name] = output
 
         cache_checks[name] = check
         cache_results[name] = output
         content_cache[content_key] = output
+
+    _process_build_settings(
+        ctx,
+        cache_results = cache_results,
+        define_results = define_results,
+        subst_results = subst_results,
+        content_cache = content_cache,
+        unquoted_defines = unquoted_defines,
+        cache_checks = cache_checks,
+        define_checks = define_checks,
+        subst_checks = subst_checks,
+        available_content_cache = available_content_cache,
+    )
 
     # Write config to JSON
     config_json = write_config_json(ctx, create_config_dict(
@@ -386,7 +479,47 @@ def autoconf_impl_common(ctx, resolve_toolchain):
 def _autoconf_impl(ctx):
     return autoconf_impl_common(ctx, resolve_toolchain = True)
 
+def to_build_settings_dict(entries):
+    """Convert a list of `checks.AC_BUILD_SETTING(...)` structs to the dict the rule attribute requires.
+
+    The `build_settings` attribute on `autoconf` / `autoconf_cache` is typed
+    `attr.label_keyed_string_dict` -- the only pre-Bazel-9 attribute type that
+    carries `(Label, str)` pairs natively. Users author build settings as a
+    list of `checks.AC_BUILD_SETTING(target=..., name=..., define=...)` calls
+    (so each entry's keyword-argument signature is self-documenting); the
+    public `autoconf` / `autoconf_cache` macros call this helper to fold that
+    list into the `{label_str: metadata_json}` shape the rule attribute
+    accepts.
+
+    Once Bazel 9 is the minimum supported version, switch the attribute to
+    `string_keyed_label_dict` (key = metadata JSON, value = build-setting
+    target), have `AC_BUILD_SETTING` return a one-key dict the user composes
+    with `|`, and delete this helper together with the wrapping macros.
+
+    Args:
+        entries: List of structs produced by `checks.AC_BUILD_SETTING(...)`,
+            or `None` / empty for no entries.
+
+    Returns:
+        A `dict[str, str]` mapping build-setting label strings to JSON
+        metadata blobs, suitable for the rule's `build_settings` attribute.
+    """
+    if not entries:
+        return {}
+    result = {}
+    for entry in entries:
+        if entry.target in result:
+            fail("Duplicate build_settings target: {}".format(entry.target))
+        result[entry.target] = entry.metadata
+    return result
+
 COMMON_ATTRS = {
+    "build_settings": attr.label_keyed_string_dict(
+        doc = "Mapping of Bazel build setting targets (any rule providing `BuildSettingInfo`) " +
+              "to JSON metadata produced by `checks.AC_BUILD_SETTING`.",
+        providers = [BuildSettingInfo],
+        default = {},
+    ),
     "checks": attr.string_list(
         doc = "List of JSON-encoded checks from checks (e.g., `checks.AC_CHECK_HEADER('stdio.h')`).",
         default = [],
@@ -411,7 +544,7 @@ This rule resolves the ``autoconf_toolchain`` (when registered) to skip redundan
 checker actions.  If a check's cache variable name already has a result in the
 toolchain or in transitive ``deps``, the existing result file is reused.
 
-Use ``autoconf_library`` instead for targets that feed into ``autoconf_toolchain``
+Use ``autoconf_cache`` instead for targets that feed into ``autoconf_toolchain``
 to avoid a dependency cycle.
 
 Example:
@@ -437,5 +570,27 @@ or wrapped source files.
     toolchains = use_cc_toolchain() + [
         config_common.toolchain_type("@rules_cc_autoconf//autoconf:toolchain_type", mandatory = False),
     ],
+    provides = [CcAutoconfInfo],
+)
+
+def _autoconf_cache_impl(ctx):
+    return autoconf_impl_common(ctx, resolve_toolchain = False)
+
+autoconf_cache = rule(
+    implementation = _autoconf_cache_impl,
+    doc = """\
+Run autoconf-like checks without resolving the autoconf toolchain.
+
+Identical to ``autoconf`` except that it does **not** resolve the
+``autoconf_toolchain``.  Use this rule for targets that are listed as
+``cache_deps`` or ``defaults`` of an ``autoconf_toolchain`` -- using the
+regular ``autoconf`` rule in that position would create a dependency cycle.
+
+Dep-level caching still applies: if a check's cache variable name already
+has a result in transitive ``deps``, the action is skipped.
+""",
+    attrs = COMMON_ATTRS,
+    fragments = ["cpp"],
+    toolchains = use_cc_toolchain(),
     provides = [CcAutoconfInfo],
 )

--- a/autoconf/tests/core/build_settings/BUILD.bazel
+++ b/autoconf/tests/core/build_settings/BUILD.bazel
@@ -1,0 +1,80 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "int_flag", "string_flag")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("//autoconf:autoconf.bzl", "autoconf")
+load("//autoconf:autoconf_hdr.bzl", "autoconf_hdr")
+load("//autoconf:checks.bzl", "checks")
+load("//autoconf/tests:diff_test.bzl", "diff_test")
+load(":transition.bzl", "transitioned_file")
+
+string_flag(
+    name = "package_name",
+    build_setting_default = "myproj",
+)
+
+bool_flag(
+    name = "enable_threads",
+    build_setting_default = True,
+)
+
+int_flag(
+    name = "log_level",
+    build_setting_default = 2,
+)
+
+autoconf(
+    name = "autoconf",
+    build_settings = [
+        checks.AC_BUILD_SETTING(
+            name = "ac_cv_package_name",
+            define = "PACKAGE_NAME",
+            target = ":package_name",
+        ),
+        checks.AC_BUILD_SETTING(
+            name = "ac_cv_enable_threads",
+            define = "ENABLE_THREADS",
+            target = ":enable_threads",
+            unquote = True,
+        ),
+        checks.AC_BUILD_SETTING(
+            name = "ac_cv_log_level",
+            define = "LOG_LEVEL",
+            target = ":log_level",
+            unquote = True,
+        ),
+    ],
+)
+
+autoconf_hdr(
+    name = "config",
+    out = "config.h",
+    template = "config.h.in",
+    deps = [":autoconf"],
+)
+
+diff_test(
+    name = "diff_test",
+    file1 = "golden_config.h.in",
+    file2 = ":config.h",
+)
+
+# Transitioned variant: overrides the three flags and re-checks the rendered
+# header so that any failure to propagate flag changes through the build
+# would diff against the golden.
+transitioned_file(
+    name = "config_transitioned",
+    actual = ":config",
+)
+
+diff_test(
+    name = "diff_test_transitioned",
+    file1 = "golden_config_transitioned.h.in",
+    file2 = ":config_transitioned",
+)
+
+cc_test(
+    name = "test_build_settings",
+    srcs = [
+        "test_build_settings.c",
+        ":config.h",
+    ],
+)

--- a/autoconf/tests/core/build_settings/config.h.in
+++ b/autoconf/tests/core/build_settings/config.h.in
@@ -1,0 +1,10 @@
+/* config.h.in - build_settings test template */
+
+/* Package name from a string_flag */
+#undef PACKAGE_NAME
+
+/* Threads toggle from a bool_flag */
+#undef ENABLE_THREADS
+
+/* Log level from an int_flag */
+#undef LOG_LEVEL

--- a/autoconf/tests/core/build_settings/golden_config.h.in
+++ b/autoconf/tests/core/build_settings/golden_config.h.in
@@ -1,0 +1,10 @@
+/* config.h.in - build_settings test template */
+
+/* Package name from a string_flag */
+#define PACKAGE_NAME "myproj"
+
+/* Threads toggle from a bool_flag */
+#define ENABLE_THREADS true
+
+/* Log level from an int_flag */
+#define LOG_LEVEL 2

--- a/autoconf/tests/core/build_settings/golden_config_transitioned.h.in
+++ b/autoconf/tests/core/build_settings/golden_config_transitioned.h.in
@@ -1,0 +1,10 @@
+/* config.h.in - build_settings test template */
+
+/* Package name from a string_flag */
+#define PACKAGE_NAME "altproj"
+
+/* Threads toggle from a bool_flag */
+#define ENABLE_THREADS false
+
+/* Log level from an int_flag */
+#define LOG_LEVEL 5

--- a/autoconf/tests/core/build_settings/test_build_settings.c
+++ b/autoconf/tests/core/build_settings/test_build_settings.c
@@ -1,0 +1,17 @@
+#include <stdbool.h>
+#include <string.h>
+
+#include "autoconf/tests/core/build_settings/config.h"
+
+int main(void) {
+    if (strcmp(PACKAGE_NAME, "myproj") != 0) {
+        return 1;
+    }
+    if (!ENABLE_THREADS) {
+        return 2;
+    }
+    if (LOG_LEVEL != 2) {
+        return 3;
+    }
+    return 0;
+}

--- a/autoconf/tests/core/build_settings/transition.bzl
+++ b/autoconf/tests/core/build_settings/transition.bzl
@@ -1,0 +1,47 @@
+"""Transition wrapper that overrides the build_settings flags for testing.
+
+Used to verify that values flowing through `checks.AC_BUILD_SETTING` actually
+re-render the produced header when the underlying build setting changes
+configuration -- not just when the user passes a different flag at the
+command line.
+"""
+
+def _transition_impl(_settings, _attr):
+    return {
+        "//autoconf/tests/core/build_settings:enable_threads": False,
+        "//autoconf/tests/core/build_settings:log_level": 5,
+        "//autoconf/tests/core/build_settings:package_name": "altproj",
+    }
+
+_transition = transition(
+    implementation = _transition_impl,
+    inputs = [],
+    outputs = [
+        "//autoconf/tests/core/build_settings:package_name",
+        "//autoconf/tests/core/build_settings:enable_threads",
+        "//autoconf/tests/core/build_settings:log_level",
+    ],
+)
+
+def _transitioned_file_impl(ctx):
+    src = ctx.attr.actual[0][DefaultInfo].files.to_list()[0]
+    out = ctx.actions.declare_file(ctx.label.name + ".h")
+    ctx.actions.symlink(output = out, target_file = src)
+    return [DefaultInfo(files = depset([out]))]
+
+transitioned_file = rule(
+    doc = "Wraps a target with a configuration transition that overrides the " +
+          "build_settings-test flags to non-default values, then re-exports its " +
+          "single output file under this rule's name.",
+    implementation = _transitioned_file_impl,
+    attrs = {
+        "actual": attr.label(
+            doc = "Target whose default output is re-emitted after the transition.",
+            cfg = _transition,
+            mandatory = True,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = Label("@bazel_tools//tools/allowlists/function_transition_allowlist"),
+        ),
+    },
+)


### PR DESCRIPTION
This change allows build settings from `bazel_skylib` to be used for checks.