### PR TITLE
Make AC_CHECK_LIB(..., "main") match GNU Autoconf

### DIFF
--- a/autoconf/checks.bzl
+++ b/autoconf/checks.bzl
@@ -181,12 +181,31 @@ choke me
 int main(void) {{ return {function}(); }}
 """
 
-# Same template — AC_CHECK_LIB and AC_SEARCH_LIBS both probe a function
-# symbol via AC_LANG_CALL → AC_LANG_FUNC_LINK_TRY upstream, so they
-# share the exact same C body. Aliasing rather than duplicating ensures
-# a future tweak to the probe shape lands everywhere in one edit.
-_AC_CHECK_LIB_TEMPLATE = _AC_CHECK_FUNC_DEFAULT_TEMPLATE
-_AC_SEARCH_LIBS_TEMPLATE = _AC_CHECK_FUNC_DEFAULT_TEMPLATE
+# GNU Autoconf's C AC_LANG_CALL omits the external function declaration when
+# FUNCTION is `main`: AC_LANG_PROGRAM necessarily defines main itself, and a
+# generic `char main (void);` declaration would conflict with that definition.
+_AC_LANG_CALL_MAIN_TEMPLATE = """\
+int main(void) { return main(); }
+"""
+
+_AC_LANG_CALL_CPP_MAIN_TEMPLATE = """\
+namespace conftest {
+extern "C" int main();
+}
+int main(void) { return conftest::main(); }
+"""
+
+def _library_function_link_test_code(function, language):
+    """Return source for AC_CHECK_LIB/AC_SEARCH_LIBS function-link probes."""
+    if function == "main":
+        if language in ["cpp", "c++"]:
+            return _AC_LANG_CALL_CPP_MAIN_TEMPLATE
+        return _AC_LANG_CALL_MAIN_TEMPLATE
+
+    # Preserve the repository's historical AC_CHECK_FUNC-shaped probe for
+    # ordinary library symbols. Its stub detection and MSVC handling differ
+    # from upstream AC_LANG_CALL; changing those results is outside this fix.
+    return _AC_CHECK_FUNC_DEFAULT_TEMPLATE.format(function = function)
 
 # AC_CHECK_TYPE probe template.
 #
@@ -1861,6 +1880,11 @@ def _ac_check_lib(
         It attempts to link against `-l<library>` to verify the library provides
         the function.
 
+        GNU Autoconf treats `function = "main"` specially. The generated program
+        supplies its own `main`, so this form tests whether the complete link
+        command accepts `-l<library>`; it does not require the library to export
+        a symbol named `main`.
+
     Args:
         library: Library name without the `-l` prefix (e.g., `"m"`, `"pthread"`)
         function: Function name to check for in the library (e.g., `"cos"`, `"pthread_create"`)
@@ -1902,13 +1926,10 @@ def _ac_check_lib(
     }
 
     # If custom code is provided, use it; otherwise generate default function check code
-    if code:
+    if code != None:
         check["code"] = code
     else:
-        # Generate default code similar to AC_CHECK_FUNC
-        check["code"] = _AC_CHECK_LIB_TEMPLATE.format(
-            function = function,
-        )
+        check["code"] = _library_function_link_test_code(function, language)
     if copts:
         check["copts"] = copts
     if linkopts:
@@ -1937,6 +1958,10 @@ def _ac_search_libs(
 
     Mirrors GNU autoconf's AC_SEARCH_LIBS. The checker tries linking the
     function without any extra library first, then with each library in order.
+
+    For `function = "main"`, the generated program supplies its own `main`.
+    Consequently, a working linker succeeds on the initial no-library attempt
+    and no candidate library is selected, matching GNU Autoconf.
 
     When `subst` is specified, a substitution variable is produced with the
     library flag value: `""` if the function is in libc or not found,
@@ -1983,10 +2008,10 @@ def _ac_search_libs(
         "type": "search_libs",
     }
 
-    if code:
+    if code != None:
         check["code"] = code
     else:
-        check["code"] = _AC_SEARCH_LIBS_TEMPLATE.format(function = function)
+        check["code"] = _library_function_link_test_code(function, language)
 
     if copts:
         check["copts"] = copts

--- a/autoconf/tests/core/libraries/BUILD.bazel
+++ b/autoconf/tests/core/libraries/BUILD.bazel
@@ -5,6 +5,7 @@ load("//autoconf:checks.bzl", "checks")
 load("//autoconf:package_info.bzl", "package_info")
 load("//autoconf/tests:diff_test.bzl", "diff_test")
 load("//autoconf/tests:gnu_autoconf_configure_test.bzl", "gnu_autoconf_configure_test")
+load(":main_check_test.bzl", "main_check_test")
 
 package_info(
     name = "package",
@@ -15,13 +16,25 @@ package_info(
 autoconf(
     name = "autoconf",
     checks = [
-        checks.AC_CHECK_LIB("m", "cos"),  # Check for math library
+        checks.AC_CHECK_LIB("m", "cos"),  # Check for a symbol in the math library
+        checks.AC_CHECK_LIB(
+            "m",
+            "main",
+            define = "HAVE_LIBM_MAIN",
+        ),  # Check whether the linker accepts the math library
         checks.AC_CHECK_LIB("pthread", "pthread_create"),  # Check for pthread library
         checks.AC_CHECK_LIB("kernel32", "GetLastError"),  # Check for Windows kernel library (Windows only)
         checks.AC_CHECK_LIB("nonexistent", "fake_function"),  # Check for non-existent library
+        checks.AC_CHECK_LIB(
+            "nonexistent",
+            "main",
+            define = "HAVE_LIBNONEXISTENT_MAIN",
+        ),  # Ensure main does not force success
     ],
     deps = [":package"],
 )
+
+main_check_test(name = "main_check_test")
 
 autoconf_hdr(
     name = "config",

--- a/autoconf/tests/core/libraries/config.h.in
+++ b/autoconf/tests/core/libraries/config.h.in
@@ -3,8 +3,14 @@
 /* Define to 1 if you have the `m' library (-lm). */
 #undef HAVE_LIBM
 
+/* Define to 1 if the linker accepts the `m' library (-lm). */
+#undef HAVE_LIBM_MAIN
+
 /* Define to 1 if you have the `nonexistent' library (-lnonexistent). */
 #undef HAVE_LIBNONEXISTENT
+
+/* Define to 1 if the linker accepts the `nonexistent' library. */
+#undef HAVE_LIBNONEXISTENT_MAIN
 
 /* Define to 1 if you have the `pthread' library (-lpthread). */
 #undef HAVE_LIBPTHREAD

--- a/autoconf/tests/core/libraries/configure.ac
+++ b/autoconf/tests/core/libraries/configure.ac
@@ -1,8 +1,14 @@
 AC_INIT([test_libraries], [1.0.0])
 AC_CONFIG_HEADERS([config.h])
 
-# Check for math library
+# Check for a symbol in the math library
 AC_CHECK_LIB([m], [cos])
+
+# Check whether the linker accepts the math library.  Using main avoids
+# compiler builtin and optimization behavior for ordinary math functions.
+AC_CHECK_LIB([m], [main],
+  [AC_DEFINE([HAVE_LIBM_MAIN], [1],
+    [Define to 1 if the linker accepts the `m' library (-lm).])])
 
 # Check for pthread library
 AC_CHECK_LIB([pthread], [pthread_create])
@@ -12,5 +18,8 @@ AC_CHECK_LIB([kernel32], [GetLastError])
 
 # Check for a library that doesn't exist
 AC_CHECK_LIB([nonexistent], [fake_function])
+AC_CHECK_LIB([nonexistent], [main],
+  [AC_DEFINE([HAVE_LIBNONEXISTENT_MAIN], [1],
+    [Define to 1 if the linker accepts the `nonexistent' library.])])
 
 AC_OUTPUT

--- a/autoconf/tests/core/libraries/golden_config_unix.h.in
+++ b/autoconf/tests/core/libraries/golden_config_unix.h.in
@@ -3,8 +3,14 @@
 /* Define to 1 if you have the `m' library (-lm). */
 #define HAVE_LIBM 1
 
+/* Define to 1 if the linker accepts the `m' library (-lm). */
+#define HAVE_LIBM_MAIN 1
+
 /* Define to 1 if you have the `nonexistent' library (-lnonexistent). */
 /* #undef HAVE_LIBNONEXISTENT */
+
+/* Define to 1 if the linker accepts the `nonexistent' library. */
+/* #undef HAVE_LIBNONEXISTENT_MAIN */
 
 /* Define to 1 if you have the `pthread' library (-lpthread). */
 #define HAVE_LIBPTHREAD 1

--- a/autoconf/tests/core/libraries/golden_config_windows.h.in
+++ b/autoconf/tests/core/libraries/golden_config_windows.h.in
@@ -3,8 +3,14 @@
 /* Define to 1 if you have the `m' library (-lm). */
 /* #undef HAVE_LIBM */
 
+/* Define to 1 if the linker accepts the `m' library (-lm). */
+/* #undef HAVE_LIBM_MAIN */
+
 /* Define to 1 if you have the `nonexistent' library (-lnonexistent). */
 /* #undef HAVE_LIBNONEXISTENT */
+
+/* Define to 1 if the linker accepts the `nonexistent' library. */
+/* #undef HAVE_LIBNONEXISTENT_MAIN */
 
 /* Define to 1 if you have the `pthread' library (-lpthread). */
 /* #undef HAVE_LIBPTHREAD */

--- a/autoconf/tests/core/libraries/main_check_test.bzl
+++ b/autoconf/tests/core/libraries/main_check_test.bzl
@@ -1,0 +1,61 @@
+"""Source-generation tests for AC_LANG_CALL([main])."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//autoconf:checks.bzl", "checks")
+
+_C_MAIN_CODE = "int main(void) { return main(); }\n"
+_CPP_MAIN_CODE = """\
+namespace conftest {
+extern "C" int main();
+}
+int main(void) { return conftest::main(); }
+"""
+_CUSTOM_CODE = "int main(void) { return 23; }"
+
+def _spec(check):
+    return json.decode(check)
+
+def _main_check_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    lib = _spec(checks.AC_CHECK_LIB(
+        "m",
+        "main",
+        define = "HAVE_LIBM",
+    ))
+    search = _spec(checks.AC_SEARCH_LIBS("main", ["missing"]))
+    cpp_lib = _spec(checks.AC_CHECK_LIB("m", "main", language = "cpp"))
+    cpp_search = _spec(checks.AC_SEARCH_LIBS("main", ["missing"], language = "cpp"))
+
+    asserts.equals(env, "ac_cv_lib_m_main", lib["name"])
+    asserts.equals(env, "m", lib["library"])
+    asserts.equals(env, "HAVE_LIBM", lib["define"])
+    asserts.equals(env, _C_MAIN_CODE, lib["code"])
+    asserts.equals(env, _C_MAIN_CODE, search["code"])
+    asserts.equals(env, _CPP_MAIN_CODE, cpp_lib["code"])
+    asserts.equals(env, _CPP_MAIN_CODE, cpp_search["code"])
+
+    asserts.equals(env, _CUSTOM_CODE, _spec(checks.AC_CHECK_LIB(
+        "m",
+        "main",
+        code = _CUSTOM_CODE,
+    ))["code"])
+    asserts.equals(env, "", _spec(checks.AC_CHECK_LIB(
+        "m",
+        "main",
+        code = "",
+    ))["code"])
+    asserts.equals(env, _CUSTOM_CODE, _spec(checks.AC_SEARCH_LIBS(
+        "main",
+        ["missing"],
+        code = _CUSTOM_CODE,
+    ))["code"])
+    asserts.equals(env, "", _spec(checks.AC_SEARCH_LIBS(
+        "main",
+        ["missing"],
+        code = "",
+    ))["code"])
+
+    return unittest.end(env)
+
+main_check_test = unittest.make(_main_check_test_impl)

--- a/autoconf/tests/core/libraries/main_check_test.bzl
+++ b/autoconf/tests/core/libraries/main_check_test.bzl
@@ -15,6 +15,12 @@ _CUSTOM_CODE = "int main(void) { return 23; }"
 def _spec(check):
     return json.decode(check)
 
+def _normalize_newlines(value):
+    return value.replace("\r\n", "\n")
+
+def _assert_generated_code_equals(env, expected, actual):
+    asserts.equals(env, _normalize_newlines(expected), _normalize_newlines(actual))
+
 def _main_check_test_impl(ctx):
     env = unittest.begin(ctx)
 
@@ -30,10 +36,10 @@ def _main_check_test_impl(ctx):
     asserts.equals(env, "ac_cv_lib_m_main", lib["name"])
     asserts.equals(env, "m", lib["library"])
     asserts.equals(env, "HAVE_LIBM", lib["define"])
-    asserts.equals(env, _C_MAIN_CODE, lib["code"])
-    asserts.equals(env, _C_MAIN_CODE, search["code"])
-    asserts.equals(env, _CPP_MAIN_CODE, cpp_lib["code"])
-    asserts.equals(env, _CPP_MAIN_CODE, cpp_search["code"])
+    _assert_generated_code_equals(env, _C_MAIN_CODE, lib["code"])
+    _assert_generated_code_equals(env, _C_MAIN_CODE, search["code"])
+    _assert_generated_code_equals(env, _CPP_MAIN_CODE, cpp_lib["code"])
+    _assert_generated_code_equals(env, _CPP_MAIN_CODE, cpp_search["code"])
 
     asserts.equals(env, _CUSTOM_CODE, _spec(checks.AC_CHECK_LIB(
         "m",

--- a/autoconf/tests/core/libraries/test_libraries.c
+++ b/autoconf/tests/core/libraries/test_libraries.c
@@ -20,12 +20,19 @@ int main(void) {
     // The math library should be available on Unix
     assert(HAVE_LIBM == 1);
 
-    // Verify we can actually use math functions
+    // The main sentinel only proves that -lm is accepted. This target links
+    // -lm explicitly and separately verifies that a math function is usable.
     double x = cos(0.0);
     assert(x > 0.99 && x < 1.01);  // cos(0) should be approximately 1
 #else
     // Math library should not be available on Windows
     // (macro is not defined)
+#endif
+
+#ifdef HAVE_LIBM_MAIN
+    assert(HAVE_LIBM_MAIN == 1);
+#else
+    // The linker should accept -lm on Unix.
 #endif
 
 #ifdef HAVE_LIBPTHREAD
@@ -47,6 +54,9 @@ int main(void) {
     // The nonexistent library should not be available
 #ifdef HAVE_LIBNONEXISTENT
     assert(0 && "HAVE_LIBNONEXISTENT should not be defined");
+#endif
+#ifdef HAVE_LIBNONEXISTENT_MAIN
+    assert(0 && "HAVE_LIBNONEXISTENT_MAIN should not be defined");
 #endif
 
     printf("Library checks passed!\n");


### PR DESCRIPTION
## Motivation

PostgreSQL uses `AC_CHECK_LIB([m], [main])` to determine whether the linker accepts `-lm`. This is deliberate: probing an ordinary math function is unreliable, because compiler builtin handling and optimization can make the call disappear before it reaches the linker. See [[PostgreSQL 17's configure.ac](https://github.com/postgres/postgres/blob/REL_17_STABLE/configure.ac#L1264-L1271)](https://github.com/postgres/postgres/blob/REL_17_STABLE/configure.ac#L1264-L1271).

rules_cc_autoconf currently generates its ordinary function-check program for this form, which produces conflicting declarations:

```c
char main(void);
int main(void)
{
    return main();
}
```

The compiler rejects that before the linker gets a chance to say whether the library is usable, so a valid `AC_CHECK_LIB("m", "main")` reports a false negative.

## Correctness fix

Generate the language-specific main programs that GNU Autoconf's `AC_LANG_CALL` machinery uses.

C:

```c
int main(void) { return main(); }
```

C++:

```cpp
namespace conftest {
extern "C" int main();
}
int main(void) { return conftest::main(); }
```

The program is linked but never executed, so the recursive reference exists only to reproduce Autoconf's link probe.

This applies to both `AC_CHECK_LIB` and `AC_SEARCH_LIBS`. For `AC_SEARCH_LIBS("main", ...)` the initial no-library attempt succeeds and no candidate library is selected, matching GNU Autoconf.

Caller-provided code still wins. The implementation now distinguishes omitted code (`None`) from an explicitly supplied empty string. Ordinary function names keep the existing template, and `AC_CHECK_FUNC` is unchanged.

## Regression coverage

The libraries test package keeps its conventional symbol probes:

```python
checks.AC_CHECK_LIB("m", "cos")
checks.AC_CHECK_LIB("nonexistent", "fake_function")
```

and adds parallel main probes:

```python
checks.AC_CHECK_LIB("m", "main", define = "HAVE_LIBM_MAIN")
checks.AC_CHECK_LIB(
    "nonexistent",
    "main",
    define = "HAVE_LIBNONEXISTENT_MAIN",
)
```

Together the tests cover:

- a linkable `-lm` succeeding with the main sentinel
- a nonexistent library still failing, which shows the result is not hard-coded and that the library argument reaches the linker
- ordinary symbol checks retaining their existing behavior
- C and C++ generating the expected source
- `AC_CHECK_LIB` and `AC_SEARCH_LIBS` preserving custom source
- the corresponding GNU Autoconf fixture producing the same configuration results

## Scope

This fixes the probe and the generated configuration result. It does not reproduce Autoconf's sequential mutation of `LIBS` which in Bazel requires resolution during analysis.

Follow-up: the ordinary AC_CHECK_LIB and AC_SEARCH_LIBS probes may benefit from a separate behavioral-fidelity review. GNU Autoconf deliberately implements these macros with language- specific AC_LANG_CALL programs, while this repository currently reuses its AC_CHECK_FUNC-shaped probe. That imports stub rejection, global C++ declarations, and MSVC-specific link behavior into checks whose upstream contract is narrowly “does this link command succeed with the candidate library?” Those differences can change probe results, but they may also embody useful compatibility behavior on supported toolchains. Resolving that tradeoff has a substantially broader compatibility surface and is intentionally outside this focused fix.